### PR TITLE
Test::Builder::ok が呼ばれる前に chdir で別のディレクトリにいると read_file が失敗する

### DIFF
--- a/lib/Test/Name/FromLine.pm
+++ b/lib/Test/Name/FromLine.pm
@@ -7,7 +7,10 @@ our $VERSION = '0.04';
 
 use Test::Builder;
 use File::Slurp;
+use File::Spec;
+use Cwd qw(getcwd);
 
+our $BASE_DIR = getcwd();
 our %filecache;
 
 no warnings 'redefine';
@@ -15,6 +18,7 @@ my $ORIGINAL_ok = \&Test::Builder::ok;
 *Test::Builder::ok = sub {
 	$_[2] ||= do {
 		my ($package, $filename, $line) = caller($Test::Builder::Level);
+		$filename = File::Spec->catfile($BASE_DIR, $filename);
 		my $file = $filecache{$filename} ||= [ read_file($filename) ];
 		my $lnum = $line;
 		$line = $file->[$lnum-1];

--- a/t/chdir.t
+++ b/t/chdir.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Differences;
+use Test::Name::FromLine;
+use File::Temp qw(tempdir);
+use Cwd qw(getcwd);
+
+sub x ($) { my $s = shift; $s =~ s{^\s+|\s+$}{}g; $s }
+sub test_test (&) { # from Test::Test::More written by id:wakabatan
+	my $code = shift;
+	open my $file1, '>', \(my $s = '');
+
+	{
+		my $builder = Test::Builder->create;
+		$builder->output($file1);
+		no warnings 'redefine';
+		local *Test::More::builder = sub { $builder };
+		$code->();
+	}
+
+	close $file1;
+
+	return { output => x $s };
+}
+
+my $base_dir = getcwd();
+my $dir = tempdir CLEANUP => 1;
+chdir $dir or die $!;
+
+is test_test {
+	is 1, 1;
+} -> {output}, x q{
+ok 1 - L32: is 1, 1;
+}, 'is 1, 1 => ok';
+
+chdir $base_dir or die $!;
+
+done_testing;


### PR DESCRIPTION
超絶レアケースなのですが、テストの一番初めで chdir などで別のディレクトリに移動していると
read_file の open で失敗してしまう問題を修正しました。

一応、Linux / Windows / Mac でテストして動作していることを確認しました。
