### PR TITLE
Use rel2abs in case filename is in absolute path already

### DIFF
--- a/lib/Test/Name/FromLine.pm
+++ b/lib/Test/Name/FromLine.pm
@@ -19,7 +19,7 @@ my $ORIGINAL_ok = \&Test::Builder::ok;
 	$_[2] ||= do {
 		my ($package, $filename, $line) = caller($Test::Builder::Level);
 		if ($filename) {
-			$filename = File::Spec->catfile($BASE_DIR, $filename);
+			$filename = File::Spec->rel2abs($filename, $BASE_DIR);
 			my $file = $filecache{$filename} ||= [ read_file($filename) ];
 			my $lnum = $line;
 			$line = $file->[$lnum-1];

--- a/t/Test.pm
+++ b/t/Test.pm
@@ -1,0 +1,7 @@
+package t::Test;
+
+sub run {
+    ::ok 1;
+}
+
+1;

--- a/t/line_from_abs.t
+++ b/t/line_from_abs.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Name::FromLine;
+
+# Run this test with prove -I$PWD
+use t::Test;
+
+t::Test::run();
+
+done_testing;


### PR DESCRIPTION
This fixes when the test functions are called within modules such as Plack::Test::Suite.
