### PR TITLE
Add :utf8 feature to cope with utf8 output hack for Test::More.

### DIFF
--- a/t/utf8hack.t
+++ b/t/utf8hack.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use utf8;   # <- here is the point for this test
+use Encode qw( encode_utf8 decode_utf8 );
+use Test::More;
+use Test::Differences;
+use Test::Name::FromLine ':utf8';
+
+sub x ($) { my $s = shift; $s =~ s{^\s+|\s+$}{}g; $s }
+sub test_test (&) { # from Test::Test::More written by id:wakabatan
+	my $code = shift;
+	#                 v- here is also the point for this test
+	open my $file1, '>:utf8', \(my $s = '');
+
+	{
+		my $builder = Test::Builder->create;
+		$builder->output($file1);
+		no warnings 'redefine';
+		local *Test::More::builder = sub { $builder };
+		$code->();
+	}
+
+	close $file1;
+
+	return { output => x $s };
+}
+
+is test_test {
+	is   1,    1;       # マルチバイトコメント
+	is   'あ', 'あ';
+	like 'あ', qr{あ};
+} -> {output}, x encode_utf8 q{
+ok 1 - L29: is   1,    1;       \# マルチバイトコメント
+ok 2 - L30: is   'あ', 'あ';
+ok 3 - L31: like 'あ', qr{あ};
+}, 'multibyte ok';
+
+is test_test {
+	TODO: {
+		local $TODO = 'あとで';
+		is   1,    1;       # マルチバイトコメント
+		is   'あ', 'あ';
+		like 'あ', qr{あ};
+	};
+} -> {output}, x encode_utf8 q{
+ok 1 - L41: is   1,    1;       \# マルチバイトコメント # TODO あとで
+ok 2 - L42: is   'あ', 'あ'; # TODO あとで
+ok 3 - L43: like 'あ', qr{あ}; # TODO あとで
+}, 'todo ok';
+
+done_testing;


### PR DESCRIPTION
Some people switch IO layer of `Test::More`'s output as ':encoding(UTF-8)' (eg. `binmode Test::Mode->builder->output, ":utf8"`) to avoid output `Wide character in print at ...` on test failures.
Yeah it's dirty hack indeed, but it does clear garbages in output of test suites away.

Conjunction of this technique and Test-Name-FromLine leads to trouble. Output of source written in multibytes become corrupted (MOJIBAKE), because IO layer with ':utf8' is going to re-encode source (already in byte stream).

Yes, that is NOT the responsibility on this module, Test-Name-FromLine (I know).
Rightful way to resolve this phenomenon is patching code of Test::More to convert UTF8 variables (and test names) into byte stream, but it is too difficult.  I gave up.
So I wrote this patch.  When `Test::Name::FromLine` is `use`d with `:utf8` parameter, automatically generated test names are decoded with UTF-8 (so they are represented in Perl internal Unicode string format), then output will be clean for multibyte even with Test::More's dirty hack.
