### PR TITLE
Fix runtime warning

### DIFF
--- a/lib/Test/Name/FromLine.pm
+++ b/lib/Test/Name/FromLine.pm
@@ -19,7 +19,7 @@ my $ORIGINAL_ok = \&Test::Builder::ok;
 	@_ = @_; # for pass and fail
 	$_[2] = do {
 		my ($package, $filename, $line) = caller($Test::Builder::Level);
-		undef $filename if $filename eq '-e';
+		undef $filename if $filename && $filename eq '-e';
 		if ($filename) {
 			$filename = File::Spec->rel2abs($filename, $BASE_DIR);
 			my $file = $filecache{$filename} ||= [ read_file($filename) ];


### PR DESCRIPTION
t/02_invalid_level.t .. Use of uninitialized value $filename in string eq at lib/Test/Name/FromLine.pm line 22.
